### PR TITLE
Remove PSR-7 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,6 @@
             "email": "mark.sagikazar@gmail.com"
         }
     ],
-    "require": {
-        "psr/http-message": "^1.0"
-    },
     "require-dev": {
         "phpspec/phpspec": "^2.4",
         "henrikbjorn/phpspec-code-coverage" : "^1.0"

--- a/spec/FulfilledPromiseSpec.php
+++ b/spec/FulfilledPromiseSpec.php
@@ -3,19 +3,17 @@
 namespace spec\Http\Promise;
 
 use Http\Promise\Promise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class FulfilledPromiseSpec extends ObjectBehavior
 {
-    function let(ResponseInterface $response)
+    function let()
     {
-        $this->beConstructedWith($response);
+        $this->beConstructedWith('result');
     }
 
-    function it_is_initializable(ResponseInterface $response)
+    function it_is_initializable()
     {
         $this->shouldHaveType('Http\Promise\FulfilledPromise');
     }
@@ -25,28 +23,24 @@ class FulfilledPromiseSpec extends ObjectBehavior
         $this->shouldImplement('Http\Promise\Promise');
     }
 
-    function it_returns_a_fulfilled_promise(ResponseInterface $response)
+    function it_returns_a_fulfilled_promise()
     {
-        $promise = $this->then(function (ResponseInterface $responseReceived) use ($response) {
-            if (Argument::is($responseReceived)->scoreArgument($response->getWrappedObject())) {
-                return $response->getWrappedObject();
-            }
+        $promise = $this->then(function ($result) {
+            return $result;
         });
 
         $promise->shouldHaveType('Http\Promise\Promise');
         $promise->shouldHaveType('Http\Promise\FulfilledPromise');
         $promise->getState()->shouldReturn(Promise::FULFILLED);
-        $promise->wait()->shouldReturn($response);
+        $promise->wait()->shouldReturn('result');
     }
 
-    function it_returns_a_rejected_promise(RequestInterface $request, ResponseInterface $response)
+    function it_returns_a_rejected_promise()
     {
         $exception = new \Exception();
 
-        $promise = $this->then(function (ResponseInterface $responseReceived) use ($response, $exception) {
-            if (Argument::is($responseReceived)->scoreArgument($response->getWrappedObject())) {
-                throw $exception;
-            }
+        $promise = $this->then(function () use ($exception) {
+            throw $exception;
         });
 
         $promise->shouldHaveType('Http\Promise\Promise');
@@ -65,13 +59,13 @@ class FulfilledPromiseSpec extends ObjectBehavior
         $this->getState()->shouldReturn(Promise::FULFILLED);
     }
 
-    function it_has_a_response(ResponseInterface $response)
+    function it_has_a_result()
     {
-        $this->wait()->shouldReturn($response);
+        $this->wait()->shouldReturn('result');
     }
 
-    function it_does_not_unwrap_a_value(ResponseInterface $response)
+    function it_does_not_unwrap_a_value()
     {
-        $this->wait(false)->shouldNotReturn($response);
+        $this->wait(false)->shouldNotReturn('result');
     }
 }

--- a/spec/RejectedPromiseSpec.php
+++ b/spec/RejectedPromiseSpec.php
@@ -3,7 +3,6 @@
 namespace spec\Http\Promise;
 
 use Http\Promise\Promise;
-use Psr\Http\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -24,21 +23,19 @@ class RejectedPromiseSpec extends ObjectBehavior
         $this->shouldImplement('Http\Promise\Promise');
     }
 
-    function it_returns_a_fulfilled_promise(ResponseInterface $response)
+    function it_returns_a_fulfilled_promise()
     {
         $exception = new \Exception();
         $this->beConstructedWith($exception);
 
-        $promise = $this->then(null, function (\Exception $exceptionReceived) use($exception, $response) {
-            if (Argument::is($exceptionReceived)->scoreArgument($exception)) {
-                return $response->getWrappedObject();
-            }
+        $promise = $this->then(null, function (\Exception $exceptionReceived) use($exception) {
+            return 'result';
         });
 
         $promise->shouldHaveType('Http\Promise\Promise');
         $promise->shouldHaveType('Http\Promise\FulfilledPromise');
         $promise->getState()->shouldReturn(Promise::FULFILLED);
-        $promise->wait()->shouldReturn($response);
+        $promise->wait()->shouldReturn('result');
     }
 
     function it_returns_a_rejected_promise()
@@ -76,7 +73,7 @@ class RejectedPromiseSpec extends ObjectBehavior
         $this->shouldThrow($exception)->duringWait();
     }
 
-    function it_does_not_unwrap_a_value(ResponseInterface $response)
+    function it_does_not_unwrap_a_value()
     {
         $this->shouldNotThrow('Exception')->duringWait(false);
     }

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -2,8 +2,6 @@
 
 namespace Http\Promise;
 
-use Psr\Http\Message\ResponseInterface;
-
 /**
  * A promise already fulfilled.
  *
@@ -12,16 +10,16 @@ use Psr\Http\Message\ResponseInterface;
 final class FulfilledPromise implements Promise
 {
     /**
-     * @var ResponseInterface
+     * @var mixed
      */
-    private $response;
+    private $result;
 
     /**
-     * @param ResponseInterface $response
+     * @param $result
      */
-    public function __construct(ResponseInterface $response)
+    public function __construct($result)
     {
-        $this->response = $response;
+        $this->result = $result;
     }
 
     /**
@@ -34,7 +32,7 @@ final class FulfilledPromise implements Promise
         }
 
         try {
-            return new self($onFulfilled($this->response));
+            return new self($onFulfilled($this->result));
         } catch (\Exception $e) {
             return new RejectedPromise($e);
         }
@@ -54,7 +52,7 @@ final class FulfilledPromise implements Promise
     public function wait($unwrap = true)
     {
         if ($unwrap) {
-            return $this->response;
+            return $this->result;
         }
     }
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -2,8 +2,6 @@
 
 namespace Http\Promise;
 
-use Psr\Http\Message\ResponseInterface;
-
 /**
  * Promise represents a value that may not be available yet, but will be resolved at some point in future.
  * It acts like a proxy to the actual value.
@@ -63,7 +61,7 @@ interface Promise
      *
      * @param bool $unwrap Whether to return resolved value / throw reason or not
      *
-     * @return ResponseInterface|null Resolved value, null if $unwrap is set to false
+     * @return mixed Resolved value, null if $unwrap is set to false
      *
      * @throws \Exception The rejection reason if $unwrap is set to true and the request failed.
      */


### PR DESCRIPTION
Although this is a BC breaking change in an RC state, I think it is not a big problem.

The idea behind separating promise was that at some point we deprecate it and rely on a PSR. That PSR will unlikely rely on PSR7, so I would say get rid of PSR-7 dependency now.