### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Change Log
 
-## 1.1.0 - 2019-11-18
+## 1.1.0 - 2020-07-07
 
 ### Added
 
-- Test with PHP 7.1, 7.2, 7.3
+- Test with PHP 7.1, 7.2, 7.3, 7.4 and 8.0
 
 ### Removed
 
-- PHP 5 support
+- PHP 5 and 7.0 support
+
+### Fixed
+
+- Fixed PHPDoc for `Promise::then`
 
 ## 1.0.0 - 2016-01-26
 


### PR DESCRIPTION
It looks like 1.1.0 was actually never tagged. I propose we release it today, if my PHP 8 PR is OK. 🚢