### PR TITLE
Refactor Promise classes with generic types (fast-tracking https://github.com/php-http/promise/pull/24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### Added
+
+- Generic annotations
+
 ## 1.1.0 - 2020-07-07
 
 ### Added

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -8,6 +8,7 @@ namespace Http\Promise;
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  *
  * @template-covariant T
+ *
  * @implements Promise<T>
  */
 final class FulfilledPromise implements Promise

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -6,14 +6,20 @@ namespace Http\Promise;
  * A promise already fulfilled.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
+ *
+ * @template-covariant T
+ * @implements Promise<T>
  */
 final class FulfilledPromise implements Promise
 {
     /**
-     * @var mixed
+     * @var T
      */
     private $result;
 
+    /**
+     * @param T $result
+     */
     public function __construct($result)
     {
         $this->result = $result;

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -12,6 +12,8 @@ namespace Http\Promise;
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ *
+ * @template-covariant T
  */
 interface Promise
 {
@@ -36,10 +38,11 @@ interface Promise
      * If you do not care about one of the cases, you can set the corresponding callable to null
      * The callback will be called when the value arrived and never more than once.
      *
-     * @param callable|null $onFulfilled called when a response will be available
-     * @param callable|null $onRejected  called when an exception occurs
+     * @param callable(T): V|null $onFulfilled called when a response will be available
+     * @param callable(\Exception): V|null $onRejected  called when an exception occurs
      *
-     * @return Promise a new resolved promise with value of the executed callback (onFulfilled / onRejected)
+     * @return Promise<V> a new resolved promise with value of the executed callback (onFulfilled / onRejected)
+     * @template V
      */
     public function then(callable $onFulfilled = null, callable $onRejected = null);
 
@@ -61,7 +64,7 @@ interface Promise
      *
      * @param bool $unwrap Whether to return resolved value / throw reason or not
      *
-     * @return mixed Resolved value, null if $unwrap is set to false
+     * @return T Resolved value, null if $unwrap is set to false
      *
      * @throws \Exception the rejection reason if $unwrap is set to true and the request failed
      */

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -38,10 +38,11 @@ interface Promise
      * If you do not care about one of the cases, you can set the corresponding callable to null
      * The callback will be called when the value arrived and never more than once.
      *
-     * @param callable(T): V|null $onFulfilled called when a response will be available
+     * @param callable(T): V|null          $onFulfilled called when a response will be available
      * @param callable(\Exception): V|null $onRejected  called when an exception occurs
      *
      * @return Promise<V> a new resolved promise with value of the executed callback (onFulfilled / onRejected)
+     *
      * @template V
      */
     public function then(callable $onFulfilled = null, callable $onRejected = null);

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -8,6 +8,7 @@ namespace Http\Promise;
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  *
  * @template-covariant T
+ *
  * @implements Promise<T>
  */
 final class RejectedPromise implements Promise

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -6,6 +6,9 @@ namespace Http\Promise;
  * A rejected promise.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
+ *
+ * @template-covariant T
+ * @implements Promise<T>
  */
 final class RejectedPromise implements Promise
 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no|yes
| New feature?    | yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes https://github.com/php-http/promise/issues/23
| Documentation   | *see below*
| License         | MIT


#### What's in this PR?
This PR refactors the Promise interface and concrete classes to use generic types. This allows to hold a meta-reference to the type of value the promise will resolve to. The then method will return a separate template type, so you can actually build properly typed then-chains.

For the Promise template, a covariant template type has been introduced. This allows library authors to create their own, constrained Promise types (say, UserPromise<U extends User>).

All in all, these annotations will improve type safety in a lot of code bases.

Regarding the docs
I'm not quite sure whether these additions should be added to the documentation (probably). WDYT?

Example Usage
I'm copying the (contrived) example from https://github.com/php-http/promise/issues/23 here:
```php
class PromiseFactory
{
    /**
     * @template T
     * @param T $value
     * @return Promise<T>
     */
    public static function make(mixed $value): Promise {
        return new SomePromiseImplementation($value);
    }
}

/** 
 * @return Promise<string>
 */
function foo(): Promise {
    return PromiseFactory::make('test');
}

// Inferred to be a string
$stringValue = foo()->wait();

// Static analysis tools will be able 
// to figure out all types involved here!
$floatValue = foo()->then(fn($value) => parseFloat($value))->wait();
```

Checklist
- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

To Do
- [ ] Discuss documentation changes