### PR TITLE
Accept Throwable for onRejected and expand return type for wait()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,3 +60,18 @@ jobs:
         run: |
           wget https://scrutinizer-ci.com/ocular.phar
           php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: PHPStan
+        uses: OskarStark/phpstan-ga@0.12.32
+        env:
+          REQUIRE_DEV: false
+        with:
+          args: analyze --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.2.1
+
+### Added
+
+- Fixed PHPDoc for `wait()` and `then()`'s `onRejected` callable
+
 ## 1.2.0 - 2023-10-24
 
 ### Added

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,6 @@
+parameters:
+    level: max
+    checkMissingIterableValueType: false
+    treatPhpDocTypesAsCertain: false
+    paths:
+        - src

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -58,6 +58,7 @@ final class FulfilledPromise implements Promise
         if ($unwrap) {
             return $this->result;
         }
+
         return;
     }
 }

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -58,5 +58,6 @@ final class FulfilledPromise implements Promise
         if ($unwrap) {
             return $this->result;
         }
+        return;
     }
 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -65,7 +65,7 @@ interface Promise
      *
      * @param bool $unwrap Whether to return resolved value / throw reason or not
      *
-     * @return T|void|null Resolved value, null if $unwrap is set to false
+     * @return ($unwrap is true ? T : null|void) Resolved value, null if $unwrap is set to false
      *
      * @throws \Exception the rejection reason if $unwrap is set to true and the request failed
      */

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -65,7 +65,7 @@ interface Promise
      *
      * @param bool $unwrap Whether to return resolved value / throw reason or not
      *
-     * @return ($unwrap is true ? T : null|void) Resolved value, null if $unwrap is set to false
+     * @return ($unwrap is true ? T : null) Resolved value, null if $unwrap is set to false
      *
      * @throws \Exception the rejection reason if $unwrap is set to true and the request failed
      */

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -39,7 +39,7 @@ interface Promise
      * The callback will be called when the value arrived and never more than once.
      *
      * @param callable(T): V|null          $onFulfilled called when a response will be available
-     * @param callable(\Exception): V|null $onRejected  called when an exception occurs
+     * @param callable(\Throwable): V|null $onRejected  called when an exception occurs
      *
      * @return Promise<V> a new resolved promise with value of the executed callback (onFulfilled / onRejected)
      *
@@ -65,7 +65,7 @@ interface Promise
      *
      * @param bool $unwrap Whether to return resolved value / throw reason or not
      *
-     * @return T Resolved value, null if $unwrap is set to false
+     * @return T|void|null Resolved value, null if $unwrap is set to false
      *
      * @throws \Exception the rejection reason if $unwrap is set to true and the request failed
      */

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -55,5 +55,6 @@ final class RejectedPromise implements Promise
         if ($unwrap) {
             throw $this->exception;
         }
+        return;
     }
 }

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -55,6 +55,7 @@ final class RejectedPromise implements Promise
         if ($unwrap) {
             throw $this->exception;
         }
+
         return;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/php-http/promise/issues/29
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

- Corrects the PHPDoc for `wait()` to handle the possible `void` and `null` return values based on the method's description.
- Uses the `\Throwable` interface instead of `\Exception` in `onRejected` callable parameter type
- Adds PHPStan configs and workflow checks to catch future issues early.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [x] Should we consider using conditional return types for `wait()` e.g. `@return ($unwrap is true ? T : null|void)`. This would eliminate further PHPStan failures for dependent libs, however this syntax requires PHPStan `^1.6.0`. Would this be a better approach? At the moment, using `T|null|void` could cause further PHPStan failures for dependent libs. Would these further failures be considered a BC break?
