### PR TITLE
Accept `Throwable` as rejection reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.2.2
+
+### Fixed
+
+- Fix accepting `Throwable` as rejection reason of a promise
+
 ## 1.2.1
 
 ### Added

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -37,8 +37,8 @@ final class FulfilledPromise implements Promise
 
         try {
             return new self($onFulfilled($this->result));
-        } catch (\Exception $e) {
-            return new RejectedPromise($e);
+        } catch (\Throwable $exception) {
+            return new RejectedPromise($exception);
         }
     }
 

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -14,11 +14,11 @@ namespace Http\Promise;
 final class RejectedPromise implements Promise
 {
     /**
-     * @var \Exception
+     * @var \Throwable
      */
     private $exception;
 
-    public function __construct(\Exception $exception)
+    public function __construct(\Throwable $exception)
     {
         $this->exception = $exception;
     }
@@ -34,8 +34,8 @@ final class RejectedPromise implements Promise
 
         try {
             return new FulfilledPromise($onRejected($this->exception));
-        } catch (\Exception $e) {
-            return new self($e);
+        } catch (\Throwable $exception) {
+            return new self($exception);
         }
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

#### What's in this PR?

The type of the constructor argument of `RejectedPromise` has been widened to accept any `Throwable`. Also, when an `Error` instance is thrown (e.g. because an unexpected type is passed to the callbacks), the promise is rejected and the chain keeps going on instead of crashing the script.

#### Why?

When `$onFulfilled` or `$onRejected` are called, an exception or error can be thrown. In the latter case, the whole script crashes abruptly because the `catch` statement, that should return a `RejectedPromise`, accepts only an instance of `Exception`. Moreover, a `RejectedPromise` cannot be constructed from a `Throwable`, because the constructor argument has the same issue. Since #30 widened the argument type of the `$onRejected` callback, this is now even more evident due to the misleading documentation.

**Before**
```php
$promise = new FulfilledPromise('Hello');
$promise = $promise->then(fn (object $value) => $value);

// PHP Fatal error: Uncaught TypeError: {closure}(): Argument #1 ($a) must be of type object, string given
```

**After**
```php
$promise = new FulfilledPromise('Hello');
$promise = $promise->then(fn (object $value) => $value);

// $promise is a RejectedPromise
```

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix