### PR TITLE
Make nullable parameter types explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.3.1 - unreleased
+
+- Made nullable parameter types explicit (PHP 8.4 compatibility)
+
 ## 1.3.0 - 2024-01-04
 
 ### Fixed

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -22,7 +22,7 @@ final class FulfilledPromise implements Promise
         $this->result = $result;
     }
 
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null)
     {
         if (null === $onFulfilled) {
             return $this;

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -41,7 +41,7 @@ interface Promise
      *
      * @return Promise a new resolved promise with value of the executed callback (onFulfilled / onRejected)
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null);
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null);
 
     /**
      * Returns the state of the promise, one of PENDING, FULFILLED or REJECTED.

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -19,7 +19,7 @@ final class RejectedPromise implements Promise
         $this->exception = $exception;
     }
 
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null)
     {
         if (null === $onRejected) {
             return $this;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         |yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT


#### What's in this PR?

This PR turns implicit nullable parameter types to explicit ones.


#### Why?

PHP allows to implicitly declare a nullable parameter type by setting the parameter's default value to `null`. However, in PHP 8.4 this syntax has been deprecated.

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types