### PR TITLE
PHP 8.4 compatibility for 1.2.* releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Change Log
+## 1.2.2
+
+### Added - 2025-10-31
+
+- Compatibility with PHP 8.4
 
 ## 1.2.1
 

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -29,7 +29,7 @@ final class FulfilledPromise implements Promise
     /**
      * {@inheritdoc}
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null)
     {
         if (null === $onFulfilled) {
             return $this;

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -45,7 +45,7 @@ interface Promise
      *
      * @template V
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null);
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null);
 
     /**
      * Returns the state of the promise, one of PENDING, FULFILLED or REJECTED.

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -26,7 +26,7 @@ final class RejectedPromise implements Promise
     /**
      * {@inheritdoc}
      */
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null)
     {
         if (null === $onRejected) {
             return $this;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| Documentation   | no
| License         | MIT


#### What's in this PR?

This PR improves the version 1.2.1 to be compatible with PHP 8.4.


#### Why?

Microsoft library for communicating with their Graph API (that is a whole MS ecosystem) in PHP relies on this library with version 1.2. Update to 1.3 is not possible as it is built on the generic annotations, which was introduced in the 1.2 version and reverted in the 1.3 version. The potential upgrade to 1.3 version would break the whole library API (the static analysis would not know the actual return types of the promises and therefore the programmer's IDEs would be lost as well).
As this prevents many people of upgrading to PHP 8.4, the easiest solution to this problem is to create new version 1.2.2 compatible with PHP 8.4 (and no other change). All other solutions are just a no-go for one reason or another – for more context and reasoning, please read this PR https://github.com/microsoft/kiota-php/pull/53.

Only for context - the library we're talking about is [microsoft/microsoft-graph](https://packagist.org/packages/microsoft/microsoft-graph). It relies on the microsoft/microsoft-graph-core, which relies through the many packages on [microsoft/kiota-abstractions](https://packagist.org/packages/microsoft/kiota-abstractions), which is built around http/promise 1.2.* with abstractions.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
